### PR TITLE
Change node version circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 executors:
   default:
     docker:
-      - image: circleci/node:8.11
+      - image: circleci/node:8.16
 
 # Orbs
 orbs:


### PR DESCRIPTION
## What it does
Change node's version

## Before

Was 8.11 and semantic was not able to make a release
![Captura de tela de 2020-07-28 14-27-29](https://user-images.githubusercontent.com/35539594/88701960-11054b00-d0e1-11ea-9473-9ec158e240d8.png)

## After

Now is 8.16
