### PR TITLE
Remove max-with from Good List Detailed

### DIFF
--- a/src/components/Goods/GoodListDetailed/styled.js
+++ b/src/components/Goods/GoodListDetailed/styled.js
@@ -8,7 +8,6 @@ export const Holder = styled.div`
   flex-direction: row;
   align-items: flex-start;
   width: 100%;
-  max-width: 16rem;
 
   @media only screen and (max-width: 500px) {
     display: none;


### PR DESCRIPTION
## What it does

Remove `max-width` from Good List Detailed

## Before

There was an `max-width: 16em`
<img width="343" alt="Captura de Tela 2020-08-05 às 17 22 18" src="https://user-images.githubusercontent.com/35539594/89460243-58728380-d740-11ea-84cd-17fc1894e91d.png">


## After

There is no  `max-width: 16em`, the user should add `max-width` on your application, the library must not limit the use of this kind of component. 
<img width="339" alt="Captura de Tela 2020-08-05 às 17 22 55" src="https://user-images.githubusercontent.com/35539594/89460253-5c9ea100-d740-11ea-876f-eb0e7ae4b223.png">
